### PR TITLE
chore: bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@0xpass/passport": "1.0.0",
-    "@0xpass/passport-viem": "1.0.0",
-    "@0xpass/webauthn-signer": "1.0.0",
+    "@0xpass/passport": "2.0.1",
+    "@0xpass/passport-viem": "2.0.0",
+    "@0xpass/webauthn-signer": "2.0.0",
     "@textea/json-viewer": "^3.2.3",
     "next": "14.1.0",
     "react": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,14 +6,14 @@ settings:
 
 dependencies:
   '@0xpass/passport':
-    specifier: 1.0.0
-    version: 1.0.0
+    specifier: 2.0.1
+    version: 2.0.1
   '@0xpass/passport-viem':
-    specifier: 1.0.0
-    version: 1.0.0(typescript@5.3.3)
+    specifier: 2.0.0
+    version: 2.0.0(typescript@5.3.3)
   '@0xpass/webauthn-signer':
-    specifier: 1.0.0
-    version: 1.0.0
+    specifier: 2.0.0
+    version: 2.0.0
   '@textea/json-viewer':
     specifier: ^3.2.3
     version: 3.2.3(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@mui/material@5.15.15)(@types/react@18.2.61)(react-dom@18.2.0)(react@18.2.0)
@@ -55,16 +55,16 @@ devDependencies:
 
 packages:
 
-  /@0xpass/models@1.0.0:
-    resolution: {integrity: sha512-LKrqzvF7m5mVEGp19Mx1JPucdrTRlrIjqcwTVAZHPxxft4BdMc2plLSWznckR+M110/kivDu92sIZXi5ZEAtHQ==}
+  /@0xpass/models@2.0.0:
+    resolution: {integrity: sha512-VwKhhNnCbOvoE3j0NoPNVtrxxM/6J09M2qHvavV3pAz5ClZ0JilydIkjuSXLcDtnBmoubofy/laxD9/OEB5Ugg==}
     dev: false
 
-  /@0xpass/passport-viem@1.0.0(typescript@5.3.3):
-    resolution: {integrity: sha512-PRMRAz6JPdvvtrbF2pRbdKxVV5q/ttAEnLOjHs2goPmT3WryikIoqcjy/562D74q48LGJ3o+CY6RzEQ8pbgorQ==}
+  /@0xpass/passport-viem@2.0.0(typescript@5.3.3):
+    resolution: {integrity: sha512-bAzyYoYUqysSJCJcMwnRL2dO3O4DLVIafs8clwb8irjDNOobjsP4bN8/46pu8Iz5sUr7iNrdSyBqyL319MH52w==}
     dependencies:
       axios: 1.6.7
       node-forge: 1.3.1
-      viem: 1.21.4(typescript@5.3.3)
+      viem: 2.9.28(typescript@5.3.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -73,10 +73,10 @@ packages:
       - zod
     dev: false
 
-  /@0xpass/passport@1.0.0:
-    resolution: {integrity: sha512-avMucFDDi92kLs1/hfLoK2lmFai/YHU3rlTGS7GzgyzQ/wm5dxXnrNCpUqZoTXDTD7SJUakNJ7WfvuTfG6wsKA==}
+  /@0xpass/passport@2.0.1:
+    resolution: {integrity: sha512-3eywO5wOP8GLNsSUuzOIZi9EuIwF+Yn0xLzyIa9CGHtayIZ5+6y8fF96szD+q7gmSn4txoV5Q0VewY5t/HNAkQ==}
     dependencies:
-      '@0xpass/models': 1.0.0
+      '@0xpass/models': 2.0.0
       axios: 1.6.7
       elliptic: 6.5.4
       js-sha3: 0.9.3
@@ -85,10 +85,10 @@ packages:
       - debug
     dev: false
 
-  /@0xpass/webauthn-signer@1.0.0:
-    resolution: {integrity: sha512-SfPrhPvpVakx6ShhS8lWipNiE2U/jqLN5e44SlXojZ7j23UfADa13AEYX94+s4CQDu40DV4pJI0JKadpC5uMMg==}
+  /@0xpass/webauthn-signer@2.0.0:
+    resolution: {integrity: sha512-4yZvURGxlMBnbfEGPg7jjIFIxwpS6mNaBtDaVtH2YdYVKM6glkprCFdn8kdDEADo3dIJfzG0sL51cARzzrI50w==}
     dependencies:
-      '@0xpass/models': 1.0.0
+      '@0xpass/models': 2.0.0
       '@github/webauthn-json': 2.1.1
       buffer: 6.0.3
     dev: false
@@ -720,6 +720,20 @@ packages:
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3 >=3.19.1
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      typescript: 5.3.3
+    dev: false
+
+  /abitype@1.0.0(typescript@5.3.3):
+    resolution: {integrity: sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.22.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1893,6 +1907,29 @@ packages:
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
       abitype: 0.9.8(typescript@5.3.3)
+      isows: 1.0.3(ws@8.13.0)
+      typescript: 5.3.3
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /viem@2.9.28(typescript@5.3.3):
+    resolution: {integrity: sha512-/1iTg8yQlCNJ+7wSmdsBNB/vhjWqFJtTH6XZXHjGXrZnlBxAtHR5ZAr5TvTJc/2nhVIVE4BkCe5JCrIiSuZodg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.0
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@scure/bip32': 1.3.2
+      '@scure/bip39': 1.2.1
+      abitype: 1.0.0(typescript@5.3.3)
       isows: 1.0.3(ws@8.13.0)
       typescript: 5.3.3
       ws: 8.13.0


### PR DESCRIPTION
Update `@0xpass/passport`, `@0xpass/passport-viem`, `@0xpass/webauthn-signer` dep versions.

License: BUSL-1.1